### PR TITLE
Fix `make rk3588-blade3-v101-linux.img` compilation bug with GCC 11

### DIFF
--- a/drivers/media/platform/rockchip/cif/capture.c
+++ b/drivers/media/platform/rockchip/cif/capture.c
@@ -6107,7 +6107,7 @@ static int rkcif_dvp_g_ch_id(struct v4l2_device *v4l2_dev,
 		if ((frm_stat & DVP_CHANNEL2_FRM_READ) ==
 		    DVP_CHANNEL2_FRM_READ)
 			v4l2_warn(v4l2_dev, "frame0/1 trigger simultaneously in DVP ID2\n");
-			*intstat &= ~DVP_FRAME_END_ID2;
+		*intstat &= ~DVP_FRAME_END_ID2;
 		return RKCIF_STREAM_MIPI_ID2;
 	}
 
@@ -6115,7 +6115,7 @@ static int rkcif_dvp_g_ch_id(struct v4l2_device *v4l2_dev,
 		if ((frm_stat & DVP_CHANNEL3_FRM_READ) ==
 		    DVP_CHANNEL3_FRM_READ)
 			v4l2_warn(v4l2_dev, "frame0/1 trigger simultaneously in DVP ID3\n");
-			*intstat &= ~DVP_FRAME_END_ID3;
+		*intstat &= ~DVP_FRAME_END_ID3;
 		return RKCIF_STREAM_MIPI_ID3;
 	}
 

--- a/drivers/video/rockchip/rga3/rga_policy.c
+++ b/drivers/video/rockchip/rga3/rga_policy.c
@@ -244,7 +244,7 @@ int rga_job_assign(struct rga_job *job)
 		    job->flags & RGA_JOB_UNSUPPORT_RGA2) {
 			if (DEBUGGER_EN(MSG))
 				pr_info("RGA2 only support under 4G memory!\n");
-				continue;
+			continue;
 		}
 
 		if (feature > 0) {


### PR DESCRIPTION
The build command `make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- rk3588-blade3-v101-linux.img` fails with GCC 11 because the `continue` statement on the modified line is indented when it should not be. This throws a `misleading-indentation` warning which is forbidden by the build flags.